### PR TITLE
🐛 Fix punteggi live mancanti sul sensore mixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,23 @@ recorder:
       - sensor.calciolive_*
   ```
 
-> ℹ️ I payload degli attributi sono già ridotti ai soli campi usati dalle card
-> (bracket, lineup, timeline, h2h), ma sensori come `sensor.calciolive_bracket_*`
-> e `sensor.calciolive_next_*` possono comunque avvicinarsi al limite di 16384 byte
-> del recorder. Escluderli con lo snippet qui sopra elimina i warning
-> *"State attributes ... exceed maximum size of 16384 bytes"* e alleggerisce il DB.
+> ⚠️ **Lo snippet qui sopra non è opzionale** per i sensori `sensor.calciolive_all_*`
+> e `sensor.calciolive_all_mixed_*`: contengono il calendario completo della stagione
+> (30-90 partite) e superano *sempre* il limite di 16384 byte del recorder. I payload
+> sono già ridotti ai soli campi usati dalle card, ma un calendario intero non può
+> stare in 16 KB. Il warning
+> *"State attributes ... exceed maximum size of 16384 bytes"* riguarda **solo** la
+> registrazione nel database: lo stato e gli attributi restano completi e le card
+> continuano a funzionare. Escludendo le entità dal recorder il warning sparisce.
 
-> ℹ️ The attribute payloads are already trimmed to only the fields the cards use
-> (bracket, lineup, timeline, h2h), but sensors like `sensor.calciolive_bracket_*`
-> and `sensor.calciolive_next_*` can still approach the recorder's 16384-byte limit.
-> Excluding them with the snippet above removes the
-> *"State attributes ... exceed maximum size of 16384 bytes"* warnings and lightens the DB.
+> ⚠️ **The snippet above is not optional** for the `sensor.calciolive_all_*` and
+> `sensor.calciolive_all_mixed_*` sensors: they carry the full season calendar
+> (30-90 matches) and will *always* exceed the recorder's 16384-byte limit. The
+> payloads are already trimmed to only the fields the cards use, but a whole season
+> cannot fit in 16 KB. The
+> *"State attributes ... exceed maximum size of 16384 bytes"* warning only affects
+> **database recording**: the state and its attributes stay complete and the cards
+> keep working. Excluding the entities from the recorder removes the warning.
 
 ## Note
     Puoi seguire più campionati o più squadre.\

--- a/custom_components/calcio_live/manifest.json
+++ b/custom_components/calcio_live/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Bobsilvio/calcio_live/issues",
   "requirements": ["arrow", "aiofiles", "pytz==2023.3"],
-  "version": "2.11.3"
+  "version": "2.11.4"
 }

--- a/custom_components/calcio_live/manifest.json
+++ b/custom_components/calcio_live/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Bobsilvio/calcio_live/issues",
   "requirements": ["arrow", "aiofiles", "pytz==2023.3"],
-  "version": "2.11.4"
+  "version": "2.11.3"
 }

--- a/custom_components/calcio_live/sensor.py
+++ b/custom_components/calcio_live/sensor.py
@@ -268,6 +268,7 @@ class CalcioLiveSensor(Entity):
                             # bracket scoreboards) can block the event loop for seconds otherwise
                             raw = await response.read()
                             data = await self.hass.async_add_executor_job(json.loads, raw)
+                            data = await self._merge_played_schedule(data)
                             _LOGGER.debug(f"Data received for {self._name}")
                             CalcioLiveSensor._cache[cache_key] = {"data": data, "time": datetime.now()}
                             # Offload heavy sync processing to executor as well
@@ -379,6 +380,47 @@ class CalcioLiveSensor(Entity):
 
         return None
 
+    async def _merge_played_schedule(self, data):
+        """Il sensore mixed usa /teams/{id}/schedule: con fixture=true ESPN
+        restituisce SOLO le partite future, senza il parametro SOLO quelle già
+        giocate. Servono entrambe, altrimenti il mixed non vede mai risultati
+        live o finali. Unisce le due risposte deduplicando per event id."""
+        if self._sensor_type != "team_matches_mixed" or not self._team_id:
+            return data
+
+        played_url = f"{self.base_url_3}/all/teams/{self._team_id}/schedule"
+        played = await self._fetch_json(played_url)
+        if not played:
+            return data
+
+        events = list(data.get("events") or [])
+        seen = {event.get("id") for event in events}
+        for event in played.get("events") or []:
+            event_id = event.get("id")
+            if event_id in seen:
+                continue
+            seen.add(event_id)
+            events.append(event)
+
+        # Le due risposte hanno ordinamenti diversi (future crescente, giocate
+        # decrescente): riordina per data crescente come lo scoreboard.
+        events.sort(key=lambda event: event.get("date") or "")
+        data["events"] = events
+        return data
+
+    async def _fetch_json(self, url):
+        """GET + parse JSON in executor. Restituisce None in caso di errore."""
+        try:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+                async with session.get(url, headers={"Accept-Language": "en"}) as response:
+                    if response.status != 200:
+                        return None
+                    raw = await response.read()
+                    return await self.hass.async_add_executor_job(json.loads, raw)
+        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as error:
+            _LOGGER.debug(f"Errore nel recupero di {url}: {error}")
+            return None
+
     async def _fetch_match_summary(self, event_id):
         """Recupera il summary completo (lineup, formation, key events) per una partita."""
         if not event_id or not self._code:
@@ -449,6 +491,16 @@ class CalcioLiveSensor(Entity):
             return None
         except (ValueError, TypeError):
             return None
+
+    def _sort_by_date_desc(self, matches):
+        """Ordina dalla più recente alla più vecchia. ESPN restituisce le
+        partite in ordine crescente, quindi senza ordinamento esplicito
+        `[0]` era la partita più VECCHIA, non l'ultima giocata."""
+        return sorted(
+            matches,
+            key=lambda m: self._parse_match_datetime(m.get("date")) or datetime(1970, 1, 1, tzinfo=timezone.utc),
+            reverse=True,
+        )
 
     def _detect_and_dispatch_goals(self, matches):
         """Rileva i goal segnati e dispatcha eventi"""
@@ -795,9 +847,9 @@ class CalcioLiveSensor(Entity):
         
         # Info ultima partita terminata (ultimi 48 ore)
         from .sensori.scoreboard import is_within_last_48_hours
-        recent_finished_matches = [m for m in matches
+        recent_finished_matches = self._sort_by_date_desc([m for m in matches
             if m.get("state") == "post" and is_within_last_48_hours(m.get("date"))
-        ]
+        ])
         if recent_finished_matches:
             last_match = recent_finished_matches[0]
             computed.update({
@@ -893,9 +945,11 @@ class CalcioLiveSensor(Entity):
                         self._state = f"🔴 {lm.get('home_team','?')} {lm.get('home_score','?')} - {lm.get('away_score','?')} {lm.get('away_team','?')} ({lm.get('clock','')})"
                     else:
                         # Priorità 2: Ultima partita terminata (più recente)
-                        finished_matches = [m for m in matches if m.get("state") == "post"]
+                        finished_matches = self._sort_by_date_desc(
+                            [m for m in matches if m.get("state") == "post"]
+                        )
                         if finished_matches:
-                            fm = finished_matches[0]  # Prima della lista = più recente
+                            fm = finished_matches[0]  # Ordinati per data: la più recente
                             self._state = f"✅ {fm.get('home_team','?')} {fm.get('home_score','?')} - {fm.get('away_score','?')} {fm.get('away_team','?')}"
                         else:
                             # Priorità 3: Prossima partita in programma

--- a/custom_components/calcio_live/sensor.py
+++ b/custom_components/calcio_live/sensor.py
@@ -268,7 +268,7 @@ class CalcioLiveSensor(Entity):
                             # bracket scoreboards) can block the event loop for seconds otherwise
                             raw = await response.read()
                             data = await self.hass.async_add_executor_job(json.loads, raw)
-                            data = await self._merge_played_schedule(data)
+                            data = await self._merge_mixed_sources(data)
                             _LOGGER.debug(f"Data received for {self._name}")
                             CalcioLiveSensor._cache[cache_key] = {"data": data, "time": datetime.now()}
                             # Offload heavy sync processing to executor as well
@@ -380,32 +380,70 @@ class CalcioLiveSensor(Entity):
 
         return None
 
-    async def _merge_played_schedule(self, data):
-        """Il sensore mixed usa /teams/{id}/schedule: con fixture=true ESPN
-        restituisce SOLO le partite future, senza il parametro SOLO quelle già
-        giocate. Servono entrambe, altrimenti il mixed non vede mai risultati
-        live o finali. Unisce le due risposte deduplicando per event id."""
+    def _event_involves_team(self, event):
+        """True se il team_id configurato è uno dei due competitor dell'evento."""
+        competitions = event.get("competitions") or []
+        competitors = competitions[0].get("competitors", []) if competitions else []
+        return any(
+            str((competitor.get("team") or {}).get("id")) == str(self._team_id)
+            for competitor in competitors
+        )
+
+    async def _merge_mixed_sources(self, data):
+        """Il sensore mixed parte da /teams/{id}/schedule?fixture=true, che
+        restituisce SOLO le partite future: senza il parametro lo stesso
+        endpoint restituisce SOLO quelle già giocate, quindi da solo non può
+        mostrare né risultati né partite in corso.
+
+        Unisce tre sorgenti deduplicando per event id:
+        - schedule?fixture=true (base): calendario futuro
+        - schedule: partite già giocate, con i risultati finali
+        - /all/scoreboard: le partite di oggi. È l'unica sorgente che espone
+          lo stato live in modo affidabile, quindi ha la precedenza sulle
+          altre due quando lo stesso evento compare più volte.
+        """
         if self._sensor_type != "team_matches_mixed" or not self._team_id:
             return data
 
-        played_url = f"{self.base_url_3}/all/teams/{self._team_id}/schedule"
-        played = await self._fetch_json(played_url)
-        if not played:
-            return data
+        events = {}
+        order = []
 
-        events = list(data.get("events") or [])
-        seen = {event.get("id") for event in events}
-        for event in played.get("events") or []:
+        def add(event, overwrite):
             event_id = event.get("id")
-            if event_id in seen:
-                continue
-            seen.add(event_id)
-            events.append(event)
+            if event_id is None:
+                return
+            previous = events.get(event_id)
+            if previous is not None:
+                if not overwrite:
+                    return
+                # /all/scoreboard non espone la competizione a livello evento:
+                # la recupero dalla versione schedule che sto sostituendo,
+                # altrimenti la partita di oggi perde league_name.
+                if not event.get("league") and previous.get("league"):
+                    event["league"] = previous["league"]
+            else:
+                order.append(event_id)
+            events[event_id] = event
 
-        # Le due risposte hanno ordinamenti diversi (future crescente, giocate
+        for event in data.get("events") or []:
+            add(event, overwrite=False)
+
+        played = await self._fetch_json(f"{self.base_url_3}/all/teams/{self._team_id}/schedule")
+        if played:
+            for event in played.get("events") or []:
+                add(event, overwrite=False)
+
+        today = await self._fetch_json(f"{self.base_url_2}/all/scoreboard")
+        if today:
+            for event in today.get("events") or []:
+                if self._event_involves_team(event):
+                    add(event, overwrite=True)
+
+        # Le sorgenti hanno ordinamenti diversi (future crescente, giocate
         # decrescente): riordina per data crescente come lo scoreboard.
-        events.sort(key=lambda event: event.get("date") or "")
-        data["events"] = events
+        merged = [events[event_id] for event_id in order]
+        merged.sort(key=lambda event: event.get("date") or "")
+        data["events"] = merged
         return data
 
     async def _fetch_json(self, url):

--- a/custom_components/calcio_live/sensor.py
+++ b/custom_components/calcio_live/sensor.py
@@ -342,6 +342,21 @@ class CalcioLiveSensor(Entity):
                 ko_year = now.year
             return f"{self.base_url_3}/{self._code}/scoreboard?limit=300&dates={ko_year}0201-{ko_year}0731"
 
+        if self._sensor_type == "team_matches_mixed" and self._team_id:
+            # Il mixed segue la squadra in TUTTE le competizioni, quindi il
+            # calendario di una singola lega non lo rappresenta. Ereditava il
+            # competition_code della config entry e con esso la sua finestra
+            # stagionale: se la squadra è configurata su una competizione il cui
+            # calendario ESPN non è ancora stato ruotato (es. uefa.champions che
+            # ad agosto 2026 riporta ancora 2025-07-01 -> 2026-07-01) il filtro
+            # di process_match_data scartava OGNI partita e il sensore restava
+            # vuoto. Le sorgenti dello schedule sono già limitate alla stagione
+            # corrente, quindi qui basta una finestra rolling larga.
+            now = datetime.now()
+            self._dyn_start_date = now - timedelta(days=365)
+            self._dyn_end_date = now + timedelta(days=365)
+            return f"{self.base_url_3}/all/teams/{self._team_id}/schedule?fixture=true"
+
         if self._code:
             season_start, season_end = await self._get_calendar_data()
 
@@ -369,8 +384,15 @@ class CalcioLiveSensor(Entity):
         elif self._sensor_type in ("match_day", "team_match", "team_matches"):
             return f"{self.base_url_3}/{self._code}/scoreboard?limit=1000&dates={season_start}-{season_end}"
 
-        elif self._sensor_type == "team_matches_mixed" and self._team_name:
-            return f"{self.base_url_3}/all/teams/{self._team_id}/schedule?fixture=true"
+        elif self._sensor_type == "team_matches_mixed":
+            # Il caso con team_id è già stato gestito sopra: qui ci si arriva
+            # solo se manca. Senza team_id l'URL sarebbe /all/teams/None/... ,
+            # cioè un 404 ripetuto a ogni update: meglio non chiamare affatto.
+            _LOGGER.error(
+                f"Team ID mancante per {self._name}: il sensore mixed non può "
+                f"essere aggiornato. Riconfigura l'integrazione indicando il Team ID."
+            )
+            return None
 
         elif self._sensor_type == "all_matches_today":
             return f"{self.base_url_2}/all/scoreboard"

--- a/custom_components/calcio_live/sensori/scoreboard.py
+++ b/custom_components/calcio_live/sensori/scoreboard.py
@@ -110,6 +110,17 @@ def process_match_data(data, hass, team_name=None, next_match_only=False, start_
             clock = status_obj.get("displayClock", "N/A")
             period = status_obj.get("period", "N/A")
 
+            # Lo scoreboard riporta "0" per una partita non ancora giocata, lo
+            # schedule lascia lo score a null. Allineiamo i due endpoint: senza
+            # questo il sensore mixed espone "N/A" e la card, che protegge dal
+            # caso solo dove controlla state == "pre", finisce per mostrare
+            # "N/A - N/A" nel popup di una partita in programma.
+            if match_state == "pre":
+                if home_score == "N/A":
+                    home_score = "0"
+                if away_score == "N/A":
+                    away_score = "0"
+
             venue_obj = competition.get("venue", {}) or {}
             venue = venue_obj.get("fullName", "N/A")
             venue_address = venue_obj.get("address", {}) or {}

--- a/custom_components/calcio_live/sensori/scoreboard.py
+++ b/custom_components/calcio_live/sensori/scoreboard.py
@@ -75,39 +75,42 @@ def process_match_data(data, hass, team_name=None, next_match_only=False, start_
             season_info = get_season_slug_or_displayname(match)
 
             competitions = match.get("competitions", [])
+            competition = competitions[0] if competitions else {}
+
             # Estrai il nome della lega/competizione
-            league_name = competitions[0].get("league", {}).get("displayName", "N/A") if competitions else "N/A"
-            
-            competitors = competitions[0].get("competitors", []) if competitions else []
+            league_name = _get_league_name(match, competition, data)
 
-            home_team_data = competitors[0].get("team", {})
+            competitors = competition.get("competitors", []) or []
+            if len(competitors) < 2:
+                continue
+
+            # L'ordine di competitors non è garantito: usa homeAway quando c'è.
+            home_competitor = next((c for c in competitors if c.get("homeAway") == "home"), competitors[0])
+            away_competitor = next((c for c in competitors if c.get("homeAway") == "away"), competitors[1])
+
+            home_team_data = home_competitor.get("team", {}) or {}
             home_team = home_team_data.get("displayName", "N/A")
-            home_logo = home_team_data.get("logo", None)
-            if not home_logo:
-                home_logos = home_team_data.get("logos", [{}])
-                home_logo = home_logos[0].get("href", "N/A")
-            home_form = competitors[0].get("form", "N/A")
-            home_score = competitors[0].get("score", "N/A")
-            home_statistics = _get_statistics(competitors[0])
+            home_logo = _get_team_logo(home_team_data)
+            home_form = home_competitor.get("form", "N/A")
+            home_score = _get_score(home_competitor)
+            home_statistics = _get_statistics(home_competitor)
 
-            away_team_data = competitors[1].get("team", {})
+            away_team_data = away_competitor.get("team", {}) or {}
             away_team = away_team_data.get("displayName", "N/A")
-            away_logo = away_team_data.get("logo", None)
-            if not away_logo:
-                away_logos = away_team_data.get("logos", [{}])
-                away_logo = away_logos[0].get("href", "N/A")
-            away_form = competitors[1].get("form", "N/A")
-            away_score = competitors[1].get("score", "N/A")
-            away_statistics = _get_statistics(competitors[1])
+            away_logo = _get_team_logo(away_team_data)
+            away_form = away_competitor.get("form", "N/A")
+            away_score = _get_score(away_competitor)
+            away_statistics = _get_statistics(away_competitor)
 
-            status_type = match.get("status", {}).get("type", {})
+            status_obj = _get_status(match, competition)
+            status_type = status_obj.get("type", {}) or {}
             match_state = status_type.get("state", "N/A")
             match_status = status_type.get("description", "N/A")
             status_detail = status_type.get("detail", "N/A")
-            clock = match.get("status", {}).get("displayClock", "N/A")
-            period = match.get("status", {}).get("period", "N/A")
+            clock = status_obj.get("displayClock", "N/A")
+            period = status_obj.get("period", "N/A")
 
-            venue_obj = competitions[0].get("venue", {}) or {}
+            venue_obj = competition.get("venue", {}) or {}
             venue = venue_obj.get("fullName", "N/A")
             venue_address = venue_obj.get("address", {}) or {}
             venue_city = venue_address.get("city", "N/A")
@@ -115,18 +118,18 @@ def process_match_data(data, hass, team_name=None, next_match_only=False, start_
 
             home_abbrev = home_team_data.get("abbreviation", "N/A")
             home_color = home_team_data.get("color", "N/A")
-            home_record = _get_record(competitors[0])
-            home_top_scorer = _get_top_scorer(competitors[0])
+            home_record = _get_record(home_competitor)
+            home_top_scorer = _get_top_scorer(home_competitor)
 
             away_abbrev = away_team_data.get("abbreviation", "N/A")
             away_color = away_team_data.get("color", "N/A")
-            away_record = _get_record(competitors[1])
-            away_top_scorer = _get_top_scorer(competitors[1])
+            away_record = _get_record(away_competitor)
+            away_top_scorer = _get_top_scorer(away_competitor)
 
-            broadcast = _get_broadcast(competitions[0])
-            attendance = competitions[0].get("attendance", 0)
+            broadcast = _get_broadcast(competition)
+            attendance = competition.get("attendance", 0)
 
-            match_details = _get_details(competitions[0].get("details", []))
+            match_details = _get_details(competition.get("details", []))
 
             if team_name and (team_name.lower() in home_team.lower() or team_name.lower() in away_team.lower()):
                 team_logo = home_logo if team_name.lower() in home_team.lower() else away_logo
@@ -232,6 +235,58 @@ def is_within_recent_window(end_time, hours=24):
 def is_within_last_48_hours(end_time):
     return is_within_recent_window(end_time, 48)
 
+def _get_status(match, competition):
+    """Lo status della partita sta a livello evento nell'endpoint scoreboard e
+    dentro competitions[0] nell'endpoint /teams/{id}/schedule (sensore mixed).
+    Senza questo fallback il mixed restituiva state/clock/period = "N/A" e non
+    riconosceva mai le partite in corso."""
+    return match.get("status") or competition.get("status") or {}
+
+
+def _get_score(competitor):
+    """Nello scoreboard lo score è una stringa ("2"), nello schedule è un dict
+    {"value": 2.0, "displayValue": "2"}. Normalizza sempre a stringa."""
+    score = competitor.get("score")
+    if isinstance(score, dict):
+        display = score.get("displayValue")
+        if display not in (None, ""):
+            return str(display)
+        value = score.get("value")
+        if value is None:
+            return "N/A"
+        if isinstance(value, float) and value.is_integer():
+            return str(int(value))
+        return str(value)
+    if score in (None, ""):
+        return "N/A"
+    return str(score)
+
+
+def _get_league_name(match, competition, data):
+    """Il nome della competizione vive in posti diversi a seconda dell'endpoint:
+    competitions[0].league, event.league (schedule) o leagues[0] (scoreboard)."""
+    for source in (competition.get("league"), match.get("league")):
+        if isinstance(source, dict):
+            name = source.get("displayName") or source.get("name")
+            if name:
+                return name
+    leagues = data.get("leagues") or []
+    if leagues:
+        return leagues[0].get("displayName") or leagues[0].get("name") or "N/A"
+    return "N/A"
+
+
+def _get_team_logo(team_data):
+    """Il logo sta in team.logo (scoreboard) o in team.logos[0].href (schedule)."""
+    logo = team_data.get("logo")
+    if logo:
+        return logo
+    logos = team_data.get("logos") or []
+    if logos:
+        return logos[0].get("href", "N/A")
+    return "N/A"
+
+
 def _get_statistics(competitor):
     statistics = {}
     stats = competitor.get("statistics", [])
@@ -265,11 +320,22 @@ def _get_top_scorer(competitor):
     return None
 
 def _get_broadcast(competition):
-    """Restituisce il primo canale TV/streaming disponibile."""
+    """Restituisce il primo canale TV/streaming disponibile.
+    Lo scoreboard espone geoBroadcasts, lo schedule solo broadcasts."""
     gbs = competition.get("geoBroadcasts", []) or []
     if gbs:
         media = gbs[0].get("media", {}) or {}
-        return media.get("shortName", "")
+        name = media.get("shortName", "")
+        if name:
+            return name
+    for broadcast in competition.get("broadcasts", []) or []:
+        media = broadcast.get("media", {}) or {}
+        name = media.get("shortName", "")
+        if name:
+            return name
+        names = broadcast.get("names") or []
+        if names:
+            return names[0]
     return ""
 
 def process_summary_data(data):


### PR DESCRIPTION
Closes #18

## Problema

Il sensore `team_matches_mixed` (`sensor.calciolive_all_mixed_*`) non ha mai mostrato punteggi live. Tre cause distinte, tutte sul percorso del mixed.

### 1. Campi letti nei posti sbagliati

Usa l'endpoint ESPN `/teams/{id}/schedule`, che ha una struttura diversa dallo `scoreboard`, ma `process_match_data` leggeva i campi dove stanno nello `scoreboard`. Verificato sui dati reali (team `124` = Borussia Dortmund):

| campo | prima | dopo |
|---|---|---|
| `state` | `N/A` sempre | `pre` / `in` / `post` |
| `home_score` / `away_score` | `N/A` | `'2'` |
| `league_name` | `N/A` sempre | `German Bundesliga`, `German Cup` |

Con `state` sempre `N/A`: `has_live_match` sempre `False`, `live_match_*` e `next_match_*` mai popolati, card senza risultati.

### 2. Una sola metà del calendario per volta

`?fixture=true` restituisce **solo** le partite future (35 eventi), senza il parametro **solo** quelle già giocate (7 eventi). Il mixed non poteva vedere risultati o partite in corso, per costruzione.

### 3. Finestra stagionale di un'altra competizione

Il mixed ereditava il `competition_code` della config entry e con esso la finestra risolta da `_get_calendar_data`. Ma segue la squadra in **tutte** le competizioni: il calendario di una singola lega non lo rappresenta. Finestre ESPN misurate il 2026-08-24:

```
ita.1            2026-06-05 -> 2027-07-01   (stagione corrente)
uefa.champions   2025-07-01 -> 2026-07-01   (non ancora ruotata)
```

Stessi dati Juventus, sola finestra diversa:

```
ita.1             45 partite (live 1, post 6, pre 38)
uefa.champions     0 partite
entry pre-v2.10    0 partite   (start/end_date salvate nel 2024)
```

Quale vinca dipende da quale config entry crea il sensore, quindi con la stessa squadra su più competizioni (es. Napoli Serie A + Napoli Champions) il risultato era di fatto casuale.

### 4. Punteggi delle partite in programma

Lo scoreboard riporta `"0"` per una partita non ancora giocata, lo schedule lascia lo score a `null`: il mixed esponeva `"N/A"` dove `sensor.calciolive_all_<lega>_*` espone `"0"`, per gli stessi identici dati. La card protegge dal caso solo dove controlla `state === "pre"` (`_matchScore`, `_isWinner`); il popup dei dettagli usa `m.home_score ?? '-'`, e `??` non intercetta la stringa `"N/A"` — aprendo una partita in programma usciva un `N/A - N/A` a caratteri cubitali.

### 5. Bonus, su tutti i sensori `all_*`

`finished_matches[0]` su una lista in ordine crescente è la partita **più vecchia**: lo stato mostrava la prima partita di stagione invece dell'ultima giocata.

## Modifiche

**`sensori/scoreboard.py`**
- `_get_status`: fallback su `competitions[0].status` (lo schedule non ha `status` a livello evento)
- `_get_score`: normalizza lo score, che nello schedule è un dict `{value, displayValue}` invece di una stringa
- `_get_league_name`: legge il nome competizione da `competitions[0].league`, `event.league` (schedule) o `leagues[0]` (scoreboard)
- `_get_team_logo`: fallback su `team.logos[0].href`
- `_get_broadcast`: fallback su `broadcasts[]` oltre a `geoBroadcasts[]`
- home/away risolti via `homeAway` invece che per posizione; eventi con meno di 2 competitors saltati invece di sollevare `IndexError` (che faceva fallire l'intero parsing)

**`sensor.py`**
- `_merge_mixed_sources`: unisce tre sorgenti deduplicando per event id — `schedule?fixture=true` (calendario futuro), `schedule` (partite giocate con i risultati) e `/all/scoreboard` filtrato sul `team_id`. Quest'ultima è l'unica che espone lo status a livello evento in modo affidabile durante una partita, quindi ha la **precedenza** sulle altre due sullo stesso event id. Sull'overwrite conserva il campo `league` della versione schedule, che `/all/scoreboard` non espone.
- `_build_url`: il mixed esce prima di `_get_calendar_data` e usa una finestra rolling (-365/+365 giorni). Le sorgenti dello schedule sono già limitate alla stagione corrente, quindi non serve altro filtro. Risparmia anche una chiamata HTTP per update.
- Il ramo mixed senza `team_id` ora logga un errore e non chiama ESPN: costruiva `/all/teams/None/schedule`, cioè un 404 ripetuto a ogni ciclo.
- `_event_involves_team`, `_fetch_json`: helper di supporto
- `_sort_by_date_desc`: ordinamento esplicito per selezionare l'ultima partita giocata
- Punteggio di default `"0"` applicato **solo** con `state == "pre"`, così una partita terminata senza punteggio resta `"N/A"` invece di essere spacciata per 0-0

**`README.md`**
- Chiarito che l'esclusione dal recorder è necessaria, non consigliata, per `all_*` e `all_mixed_*`: il calendario completo (34-45 partite, ~30-38 KB misurati) non può stare in 16384 byte. Il warning riguarda solo la scrittura su DB — stato, attributi e card restano completi.

## Verifica

Parsing eseguito sui payload ESPN reali di tutti gli endpoint usati dall'integrazione (`ger.1/scoreboard`, `ita.1/scoreboard`, `all/scoreboard`, `all/teams/{id}/schedule`, `all/teams/{id}/schedule?fixture=true`): stato, punteggi, loghi e nome competizione corretti su tutti, nessuna regressione sui sensori che usano lo `scoreboard`.

Pipeline completa del mixed testata su Juventus (45 partite da 3 sorgenti) con un evento forzato a `state="in"`: nessun duplicato, ordinamento crescente, stato `🔴 Frosinone 1 - 2 Juventus (58')`, `league_name` `Italian Serie A`. `_sort_by_date_desc` seleziona l'11/08 come ultima giocata invece del 18/07 (un'amichevole) che uscirebbe senza ordinamento.

### Conferma sul campo (27/08)

L'assunzione alla base del merge — `fixture=true` = non ancora giocate, senza parametro = giocate — non era verificabile il 23/08 perché non c'era nessuna partita in corso al mondo. Quattro giorni dopo, l'evento `401874930` (Frosinone-Juventus, 23/08) è **migrato** fra i due endpoint:

| | 23/08 (prima del match) | 27/08 (dopo) |
|---|---|---|
| `schedule?fixture=true` | presente (39 ev.) | assente (38 ev.) |
| `schedule` | assente (6 ev.) | presente (7 ev.) |

Senza il merge il sensore avrebbe perso il risultato: prima del match stava solo in `fixture=true`, dopo solo nell'endpoint che il sensore non chiamava. Pipeline rieseguita su dati reali freschi, senza alcuna iniezione sintetica: 45 partite, 7 risultati recuperati, stato `✅ Frosinone 0 - 1 Juventus` (il risultato vero), prossima `Juventus vs Parma [Italian Serie A]`. Senza `_sort_by_date_desc` lo stato mostrerebbe un'amichevole del 18/07.

## Rapporto con #17

Verificato con `git merge-tree`: i due branch **si fondono senza conflitti**, e nell'albero risultante entrambi i set di modifiche restano intatti e sintatticamente validi. Il fallback introdotto da #17 non passa da `_merge_mixed_sources`, ma si applica solo a `match_day`/`team_match`/`team_matches`, quindi non lascia buchi sul mixed.

