### PR TITLE
🐛 Serie A vuota: rispetta il limite di 365 giorni di ESPN + classifica robusta

### DIFF
--- a/custom_components/calcio_live/sensor.py
+++ b/custom_components/calcio_live/sensor.py
@@ -10,6 +10,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import random
 from .const import DOMAIN, _LOGGER
 
+# ESPN risponde HTTP 400 ("Failed to get events endpoint.") ai range di date
+# più lunghi di 365 giorni. La soglia è netta: 365 giorni -> 200, 366 -> 400.
+# Alcune leghe espongono un calendario stagionale più largo di così (es. Serie A
+# 2026-06-05 -> 2027-07-01, 391 giorni), quindi la richiesta falliva sempre.
+MAX_ESPN_RANGE_DAYS = 365
+
 # Competizioni con fase a eliminazione diretta (knockout bracket)
 KNOCKOUT_LEAGUES = {
     "uefa.champions",
@@ -359,6 +365,8 @@ class CalcioLiveSensor(Entity):
             season_start = self._start_date.strftime("%Y-%m-%d")
             season_end = self._end_date.strftime("%Y-%m-%d")
 
+        season_start, season_end = self._clamp_espn_range(season_start, season_end)
+
         season_start = season_start[:10].replace("-", "")
         season_end = season_end[:10].replace("-", "")
 
@@ -378,6 +386,41 @@ class CalcioLiveSensor(Entity):
             return f"{self.base_url_2}/{self._code}/news?limit=15"
 
         return None
+
+    def _clamp_espn_range(self, season_start, season_end):
+        """Riduce il range di date entro il limite accettato da ESPN.
+
+        ESPN rifiuta con 400 qualsiasi finestra più lunga di MAX_ESPN_RANGE_DAYS,
+        e diverse leghe hanno un calendario stagionale più largo: la Serie A
+        dichiara 2026-06-05 -> 2027-07-01 (391 giorni), quindi ogni richiesta di
+        match_day/team_match/team_matches falliva, il sensore restava su
+        "Nessuna partita disponibile" e ogni update sprecava 3 tentativi con 5
+        secondi di attesa ciascuno.
+
+        Teniamo l'inizio stagione e tagliamo la fine: una stagione dura ~10 mesi,
+        quindi start+365 la copre comunque per intero. Se però quella finestra
+        si chiude prima di oggi (siamo nella coda di padding del calendario),
+        ancoriamo il range alla fine per non perdere il presente.
+        """
+        try:
+            start = datetime.strptime(season_start[:10], "%Y-%m-%d")
+            end = datetime.strptime(season_end[:10], "%Y-%m-%d")
+        except (ValueError, TypeError):
+            return season_start, season_end
+
+        if (end - start).days <= MAX_ESPN_RANGE_DAYS:
+            return season_start, season_end
+
+        clamped_end = start + timedelta(days=MAX_ESPN_RANGE_DAYS)
+        if clamped_end < datetime.now():
+            start = end - timedelta(days=MAX_ESPN_RANGE_DAYS)
+            clamped_end = end
+
+        _LOGGER.debug(
+            f"Range ESPN ridotto per {self._name}: {season_start[:10]}-{season_end[:10]} "
+            f"({(end - start).days} giorni) -> {start:%Y-%m-%d}-{clamped_end:%Y-%m-%d}"
+        )
+        return start.strftime("%Y-%m-%d"), clamped_end.strftime("%Y-%m-%d")
 
     async def _fetch_match_summary(self, event_id):
         """Recupera il summary completo (lineup, formation, key events) per una partita."""

--- a/custom_components/calcio_live/sensor.py
+++ b/custom_components/calcio_live/sensor.py
@@ -323,6 +323,41 @@ class CalcioLiveSensor(Entity):
         first.update(summary_data)
 
     
+    def _clamp_espn_range(self, season_start, season_end):
+        """Riduce il range di date entro il limite accettato da ESPN.
+
+        ESPN rifiuta con 400 qualsiasi finestra più lunga di MAX_ESPN_RANGE_DAYS,
+        e diverse leghe hanno un calendario stagionale più largo: la Serie A
+        dichiara 2026-06-05 -> 2027-07-01 (391 giorni), quindi ogni richiesta di
+        match_day/team_match/team_matches falliva, il sensore restava su
+        "Nessuna partita disponibile" e ogni update sprecava 3 tentativi con 5
+        secondi di attesa ciascuno.
+
+        Teniamo l'inizio stagione e tagliamo la fine: una stagione dura ~10 mesi,
+        quindi start+365 la copre comunque per intero. Se però quella finestra
+        si chiude prima di oggi (siamo nella coda di padding del calendario),
+        ancoriamo il range alla fine per non perdere il presente.
+        """
+        try:
+            start = datetime.strptime(season_start[:10], "%Y-%m-%d")
+            end = datetime.strptime(season_end[:10], "%Y-%m-%d")
+        except (ValueError, TypeError):
+            return season_start, season_end
+
+        if (end - start).days <= MAX_ESPN_RANGE_DAYS:
+            return season_start, season_end
+
+        clamped_end = start + timedelta(days=MAX_ESPN_RANGE_DAYS)
+        if clamped_end < datetime.now():
+            start = end - timedelta(days=MAX_ESPN_RANGE_DAYS)
+            clamped_end = end
+
+        _LOGGER.debug(
+            f"Range ESPN ridotto per {self._name}: {season_start[:10]}-{season_end[:10]} "
+            f"({(end - start).days} giorni) -> {start:%Y-%m-%d}-{clamped_end:%Y-%m-%d}"
+        )
+        return start.strftime("%Y-%m-%d"), clamped_end.strftime("%Y-%m-%d")
+
     async def _build_url(self):
         base_url    = "https://site.web.api.espn.com/apis/v2/sports/soccer"
         base_url_2  = "https://site.api.espn.com/apis/site/v2/sports/soccer"
@@ -386,41 +421,6 @@ class CalcioLiveSensor(Entity):
             return f"{self.base_url_2}/{self._code}/news?limit=15"
 
         return None
-
-    def _clamp_espn_range(self, season_start, season_end):
-        """Riduce il range di date entro il limite accettato da ESPN.
-
-        ESPN rifiuta con 400 qualsiasi finestra più lunga di MAX_ESPN_RANGE_DAYS,
-        e diverse leghe hanno un calendario stagionale più largo: la Serie A
-        dichiara 2026-06-05 -> 2027-07-01 (391 giorni), quindi ogni richiesta di
-        match_day/team_match/team_matches falliva, il sensore restava su
-        "Nessuna partita disponibile" e ogni update sprecava 3 tentativi con 5
-        secondi di attesa ciascuno.
-
-        Teniamo l'inizio stagione e tagliamo la fine: una stagione dura ~10 mesi,
-        quindi start+365 la copre comunque per intero. Se però quella finestra
-        si chiude prima di oggi (siamo nella coda di padding del calendario),
-        ancoriamo il range alla fine per non perdere il presente.
-        """
-        try:
-            start = datetime.strptime(season_start[:10], "%Y-%m-%d")
-            end = datetime.strptime(season_end[:10], "%Y-%m-%d")
-        except (ValueError, TypeError):
-            return season_start, season_end
-
-        if (end - start).days <= MAX_ESPN_RANGE_DAYS:
-            return season_start, season_end
-
-        clamped_end = start + timedelta(days=MAX_ESPN_RANGE_DAYS)
-        if clamped_end < datetime.now():
-            start = end - timedelta(days=MAX_ESPN_RANGE_DAYS)
-            clamped_end = end
-
-        _LOGGER.debug(
-            f"Range ESPN ridotto per {self._name}: {season_start[:10]}-{season_end[:10]} "
-            f"({(end - start).days} giorni) -> {start:%Y-%m-%d}-{clamped_end:%Y-%m-%d}"
-        )
-        return start.strftime("%Y-%m-%d"), clamped_end.strftime("%Y-%m-%d")
 
     async def _fetch_match_summary(self, event_id):
         """Recupera il summary completo (lineup, formation, key events) per una partita."""

--- a/custom_components/calcio_live/sensor.py
+++ b/custom_components/calcio_live/sensor.py
@@ -16,6 +16,43 @@ from .const import DOMAIN, _LOGGER
 # 2026-06-05 -> 2027-07-01, 391 giorni), quindi la richiesta falliva sempre.
 MAX_ESPN_RANGE_DAYS = 365
 
+
+def _clamp_espn_range(season_start, season_end, sensor_name=""):
+    """Riduce il range di date entro il limite accettato da ESPN.
+
+    ESPN rifiuta con 400 qualunque finestra più lunga di MAX_ESPN_RANGE_DAYS, e
+    diverse leghe hanno un calendario stagionale più largo: la Serie A dichiara
+    2026-06-05 -> 2027-07-01 (391 giorni), quindi ogni richiesta di
+    match_day/team_match/team_matches falliva, il sensore restava su "Nessuna
+    partita disponibile" e ogni update sprecava 3 tentativi con 5 secondi di
+    attesa ciascuno.
+
+    Teniamo l'inizio stagione e tagliamo la fine: una stagione dura ~10 mesi,
+    quindi start+365 la copre comunque per intero. Se però quella finestra si
+    chiude prima di oggi (siamo nella coda di padding del calendario) ancoriamo
+    il range alla fine, per non perdere il presente.
+    """
+    try:
+        start = datetime.strptime(season_start[:10], "%Y-%m-%d")
+        end = datetime.strptime(season_end[:10], "%Y-%m-%d")
+    except (ValueError, TypeError):
+        return season_start, season_end
+
+    if (end - start).days <= MAX_ESPN_RANGE_DAYS:
+        return season_start, season_end
+
+    clamped_end = start + timedelta(days=MAX_ESPN_RANGE_DAYS)
+    if clamped_end < datetime.now():
+        start = end - timedelta(days=MAX_ESPN_RANGE_DAYS)
+        clamped_end = end
+
+    _LOGGER.debug(
+        f"Range ESPN ridotto per {sensor_name}: {season_start[:10]}-{season_end[:10]} "
+        f"({(end - start).days} giorni) -> {start:%Y-%m-%d}-{clamped_end:%Y-%m-%d}"
+    )
+    return start.strftime("%Y-%m-%d"), clamped_end.strftime("%Y-%m-%d")
+
+
 # Competizioni con fase a eliminazione diretta (knockout bracket)
 KNOCKOUT_LEAGUES = {
     "uefa.champions",
@@ -323,41 +360,6 @@ class CalcioLiveSensor(Entity):
         first.update(summary_data)
 
     
-    def _clamp_espn_range(self, season_start, season_end):
-        """Riduce il range di date entro il limite accettato da ESPN.
-
-        ESPN rifiuta con 400 qualsiasi finestra più lunga di MAX_ESPN_RANGE_DAYS,
-        e diverse leghe hanno un calendario stagionale più largo: la Serie A
-        dichiara 2026-06-05 -> 2027-07-01 (391 giorni), quindi ogni richiesta di
-        match_day/team_match/team_matches falliva, il sensore restava su
-        "Nessuna partita disponibile" e ogni update sprecava 3 tentativi con 5
-        secondi di attesa ciascuno.
-
-        Teniamo l'inizio stagione e tagliamo la fine: una stagione dura ~10 mesi,
-        quindi start+365 la copre comunque per intero. Se però quella finestra
-        si chiude prima di oggi (siamo nella coda di padding del calendario),
-        ancoriamo il range alla fine per non perdere il presente.
-        """
-        try:
-            start = datetime.strptime(season_start[:10], "%Y-%m-%d")
-            end = datetime.strptime(season_end[:10], "%Y-%m-%d")
-        except (ValueError, TypeError):
-            return season_start, season_end
-
-        if (end - start).days <= MAX_ESPN_RANGE_DAYS:
-            return season_start, season_end
-
-        clamped_end = start + timedelta(days=MAX_ESPN_RANGE_DAYS)
-        if clamped_end < datetime.now():
-            start = end - timedelta(days=MAX_ESPN_RANGE_DAYS)
-            clamped_end = end
-
-        _LOGGER.debug(
-            f"Range ESPN ridotto per {self._name}: {season_start[:10]}-{season_end[:10]} "
-            f"({(end - start).days} giorni) -> {start:%Y-%m-%d}-{clamped_end:%Y-%m-%d}"
-        )
-        return start.strftime("%Y-%m-%d"), clamped_end.strftime("%Y-%m-%d")
-
     async def _build_url(self):
         base_url    = "https://site.web.api.espn.com/apis/v2/sports/soccer"
         base_url_2  = "https://site.api.espn.com/apis/site/v2/sports/soccer"
@@ -400,7 +402,7 @@ class CalcioLiveSensor(Entity):
             season_start = self._start_date.strftime("%Y-%m-%d")
             season_end = self._end_date.strftime("%Y-%m-%d")
 
-        season_start, season_end = self._clamp_espn_range(season_start, season_end)
+        season_start, season_end = _clamp_espn_range(season_start, season_end, self._name)
 
         season_start = season_start[:10].replace("-", "")
         season_end = season_end[:10].replace("-", "")

--- a/custom_components/calcio_live/sensori/classifica.py
+++ b/custom_components/calcio_live/sensori/classifica.py
@@ -10,16 +10,19 @@ def classifica_data(data):
             standings = []
 
             for index, entry in enumerate(standings_data, start=1):
-                team = entry.get("team", {})
-                stats = {stat['name']: stat['displayValue'] for stat in entry.get("stats", [])}
+                team = entry.get("team", {}) or {}
+                stats = {
+                    stat.get("name"): stat.get("displayValue")
+                    for stat in entry.get("stats", []) or []
+                }
 
-                rank = entry.get("note", {}).get("rank", index)
+                rank = (entry.get("note") or {}).get("rank", index)
 
                 team_data = {
                     "rank": rank,
                     "team_id": team.get("id"),
                     "team_name": team.get("displayName"),
-                    "team_logo": team.get("logos", [])[0].get("href"),
+                    "team_logo": _get_logo(team),
                     "points": stats.get("points", "N/A"),
                     "games_played": stats.get("gamesPlayed", "N/A"),
                     "wins": stats.get("wins", "N/A"),
@@ -39,8 +42,16 @@ def classifica_data(data):
                 "full_table_link": full_table_link
             })
 
-        seasons_data = data.get("seasons", [])
-        current_season = next((s for s in seasons_data if s.get("year") == 2024), None)
+        # La stagione corrente sta nel campo "season" a livello top. Prima
+        # veniva cercata in "seasons" con l'anno 2024 scritto a mano: dal 2025
+        # in poi non trovava più nulla e season/season_start/season_end
+        # restavano "N/A". Come fallback prendiamo l'anno più recente.
+        current_season = data.get("season") or {}
+        if not current_season:
+            seasons_data = data.get("seasons", []) or []
+            current_season = max(
+                seasons_data, key=lambda s: s.get("year", 0), default=None
+            )
 
         season_display_name = current_season.get("displayName", "N/A") if current_season else "N/A"
         season_start = _parse_date(current_season.get("startDate", "N/A")) if current_season else None
@@ -56,6 +67,16 @@ def classifica_data(data):
         _LOGGER.error(f"Errore nel processare i dati della classifica: {e}")
         return {}
 
+
+
+def _get_logo(team):
+    """Alcune squadre non hanno loghi (es. Torreense in Europa League): prima
+    l'indice [0] sollevava IndexError e faceva fallire l'INTERA classifica,
+    che tornava {} e riprovava a ogni update."""
+    logos = team.get("logos") or []
+    if logos:
+        return logos[0].get("href")
+    return None
 
 
 def _parse_date(date_str):


### PR DESCRIPTION
Closes #20

Due bug distinti, entrambi riprodotti sui dati ESPN live.

## 1. ESPN rifiuta i range oltre 365 giorni

I sensori Serie A (`all_italian_serie_a`, `all_ita_1_*`, `next_ita_1_*`) davano sempre "Nessuna partita disponibile", mentre Liga e Premier funzionavano.

Causa: ESPN risponde `HTTP 400 {"code":400,"message":"Failed to get events endpoint."}` a qualunque finestra più lunga di **365 giorni**. La soglia è netta:

```
20260605-20270601  (361 giorni) -> 200
20260605-20270605  (365 giorni) -> 200
20260605-20270606  (366 giorni) -> 400   <-- soglia
20260605-20270701  (391 giorni) -> 400   <-- quello che usava l'integrazione
```

La Serie A dichiara un calendario `2026-06-05 -> 2027-07-01`, cioè **391 giorni**: ogni richiesta falliva, sempre, in modo deterministico.

Le altre leghe non erano fortunate, erano **al limite**: Bundesliga, Liga, Premier ed Europa League dichiarano tutte esattamente 365 giorni. Funzionavano per un giorno di margine. Il clamp protegge anche loro.

Questo spiega anche i due warning nei log dell'issue: 3 tentativi × 5 secondi di attesa a ogni update producono `Updating calcio_live sensor took longer than the scheduled update interval` e `is taking over 10 seconds`.

`_clamp_espn_range` tiene l'inizio stagione e taglia la fine a `start+365`: una stagione dura ~10 mesi, quindi la copre comunque per intero. Se quella finestra si chiude prima di oggi (coda di padding del calendario) il range viene invece ancorato alla fine, per non perdere il presente.

**Verificato su ESPN live:**

| lega | finestra dichiarata | dopo il clamp | eventi |
|---|---|---|---|
| ita.1 | 2026-06-05 → 2027-07-01 (391g) | 2026-06-05 → 2027-06-05 | **0 → 380** |
| ger.1 | 2026-07-01 → 2027-07-01 (365g) | invariata | 306 |
| esp.1 / eng.1 | 365g | invariata | 380 |
| uefa.europa | 365g | invariata | 144 |

Con la squadra dell'issue: Juventus 38 partite, AC Milan 38, `match_day` 380. La prossima partita risolta correttamente a `06/09/2026 20:45 Juventus vs AC Milan`.

Casi limite coperti: finestra corta (invariata), finestra interamente nel passato (ancorata alla fine), date non parsabili (restituite intatte).

## 2. Una squadra senza logo distruggeva l'intera classifica

`Errore nel processare i dati della classifica: list index out of range`, 1704 occorrenze nei log dell'issue.

**Torreense** (Europa League, id 21615) non ha loghi. `team.get("logos", [])[0]` sollevava `IndexError`, l'`except` di `classifica_data` inghiottiva tutto e restituiva `{}`: si perdeva la classifica **intera**, non la singola squadra, e si riprovava a ogni update.

Il segnalatore scriveva "Sensore classifica invece OK" perché la sua Serie A funzionava — l'errore veniva dalla sua Europa League, come lui stesso sospettava a fine commento.

Nella stessa funzione: la stagione corrente veniva cercata in `seasons` con l'anno **2024 scritto a mano**, quindi dal 2025 in poi `season`, `season_start` e `season_end` erano `"N/A"` per tutti. Ora legge il campo `season` a livello top, con fallback sull'anno più recente.

**Verificato su 6 leghe:**

| lega | prima | dopo |
|---|---|---|
| uefa.europa | `{}` — classifica persa | 36 squadre |
| ita.1 / esp.1 / eng.1 / ger.1 / uefa.champions | OK ma `season: 2024-25` | OK, `season: 2026-27` |

Irrobustiti anche `note`, `stats` e `team` contro valori `null`.

## Rapporto con le altre PR

`_clamp_espn_range` è a livello di modulo, in testa al file accanto alla costante che documenta il limite, proprio per non collidere con gli helper aggiunti da #19 né con la pulizia degli spazi di #17.

Verificato con `git merge-tree`: questo branch si fonde pulito con **`main`, #17 e #19 singolarmente**, e anche con **#17 + #19 insieme**. Nell'albero a tre tutti i file parsano e tutte le funzionalità dei tre PR sono presenti.

Nota: il fallback di #17 resta utile come rete di sicurezza, ma non risolve questa causa — scatta solo dopo 15 secondi di tentativi e recupera una finestra ridotta di -30/+60 giorni. Con il clamp la richiesta primaria riesce al primo colpo e il calendario resta completo.

Nessun bump di versione: si accompagna alla 2.11.4 di #19.
