### PR TITLE
🐛 Stop alle notifiche a raffica + scan_interval finalmente rispettato

### DIFF
--- a/custom_components/calcio_live/sensor.py
+++ b/custom_components/calcio_live/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.storage import Store
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
 import random
 from .const import DOMAIN, _LOGGER
 
@@ -188,6 +189,7 @@ class CalcioLiveSensor(Entity):
         # Traccia le partite per cui è stato dispatchato l'evento di fine
         self._match_finished_dispatched = set()
         self._store = None
+        self._unsub_interval = None
 
         self.base_url = "https://site.web.api.espn.com/apis/v2/sports/soccer"
         self.base_url_2 = "https://site.api.espn.com/apis/site/v2/sports/soccer"
@@ -204,6 +206,29 @@ class CalcioLiveSensor(Entity):
             _LOGGER.debug(
                 f"Caricati {len(self._match_finished_dispatched)} match_finished da storage per {self._name}"
             )
+
+        # scan_interval veniva salvato su self._scan_interval e mai usato: senza
+        # una costante SCAN_INTERVAL nel modulo, HA applicava il proprio default
+        # del dominio sensor (30 secondi) a TUTTI i sensori, ignorando i 3
+        # minuti configurati. Schedulando noi l'update, l'opzione torna a valere
+        # e si smette di martellare ESPN.
+        self._unsub_interval = async_track_time_interval(
+            self.hass, self._async_scheduled_update, self._scan_interval
+        )
+
+    async def _async_scheduled_update(self, now=None):
+        """Update periodico, sostituisce il polling di HA."""
+        try:
+            await self.async_update()
+        except Exception as error:  # non lasciamo morire il timer
+            _LOGGER.error(f"Errore nell'update di {self._name}: {error}")
+        self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self):
+        """Ferma il timer quando l'entità viene rimossa."""
+        if self._unsub_interval:
+            self._unsub_interval()
+            self._unsub_interval = None
 
     async def _save_match_finished_store(self):
         """Salva il set dei match_finished nel file .storage di HA."""
@@ -230,7 +255,9 @@ class CalcioLiveSensor(Entity):
 
     @property
     def should_poll(self):
-        return True
+        # Il polling lo gestiamo noi in async_added_to_hass: HA non sa nulla
+        # dell'intervallo per-entità configurato dall'utente.
+        return False
 
     @property
     def unique_id(self):
@@ -767,10 +794,14 @@ class CalcioLiveSensor(Entity):
 
     def _compute_all_matches_attributes(self, matches):
         """Computa attributi per tutte le partite"""
-        # Dispatch eventi solo per i sensori principali.
-        # team_matches_mixed coprirebbe le stesse partite già gestite da team_matches,
-        # causando eventi duplicati per ogni cartellino/goal/fine partita.
-        if self._sensor_type != "team_matches_mixed":
+        # Dispatch eventi solo per i sensori legati a UNA squadra seguita.
+        # - team_matches_mixed coprirebbe le stesse partite già gestite da
+        #   team_matches, causando eventi duplicati per ogni cartellino/goal.
+        # - all_matches_today legge lo scoreboard globale di ESPN, che contiene
+        #   ~100 partite di tutte le leghe del mondo: emettere eventi da lì
+        #   significa notificare gol e cartellini di partite che l'utente non
+        #   segue. È la causa delle notifiche a raffica di #11 e #13.
+        if self._sensor_type not in ("team_matches_mixed", "all_matches_today"):
             self._detect_and_dispatch_goals(matches)
             self._detect_and_dispatch_cards(matches)
             self._detect_and_dispatch_match_finished(matches)

--- a/custom_components/calcio_live/sensor.py
+++ b/custom_components/calcio_live/sensor.py
@@ -217,12 +217,22 @@ class CalcioLiveSensor(Entity):
         )
 
     async def _async_scheduled_update(self, now=None):
-        """Update periodico, sostituisce il polling di HA."""
+        """Update periodico, sostituisce il polling di HA.
+
+        Passa da async_update_ha_state(force_refresh=True), non da
+        async_update() diretta: async_track_time_interval schedula il tick
+        successivo PRIMA di eseguire il job e lo lancia in background, quindi
+        due update possono sovrapporsi se una richiesta a ESPN dura più
+        dell'intervallo. async_update_ha_state passa per async_device_update,
+        che ha la guardia di rientranza `_update_staged` e scarta il tick
+        sovrapposto: senza, due esecuzioni concorrenti andrebbero in race su
+        _previous_scores e _previous_match_details, con eventi gol/cartellino
+        duplicati o stato più vecchio scritto dopo quello più recente.
+        """
         try:
-            await self.async_update()
+            await self.async_update_ha_state(force_refresh=True)
         except Exception as error:  # non lasciamo morire il timer
             _LOGGER.error(f"Errore nell'update di {self._name}: {error}")
-        self.async_write_ha_state()
 
     async def async_will_remove_from_hass(self):
         """Ferma il timer quando l'entità viene rimossa."""
@@ -431,7 +441,9 @@ class CalcioLiveSensor(Entity):
 
         calendar_url = f"{self.base_url_2}/{self._code}/scoreboard"
         try:
-            async with aiohttp.ClientSession() as session:
+            # Senza timeout esplicito aiohttp attende fino a 5 minuti: un update
+            # poteva restare appeso ben oltre lo scan_interval.
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
                 async with session.get(calendar_url, headers={"Accept-Language": "en"}) as response:
                     response.raise_for_status()
                     raw = await response.read()


### PR DESCRIPTION
Closes #11
Closes #13

Due bug che si alimentano a vicenda, entrambi aperti da mesi.

## 1. Il sensore "tutte le partite" notificava il mondo intero

Il dispatch di gol, cartellini e fine partita escludeva solo `team_matches_mixed`:

```python
if self._sensor_type != "team_matches_mixed":
    self._detect_and_dispatch_goals(matches)
    ...
```

Ma `all_matches_today` legge lo scoreboard **globale** di ESPN, che oggi contiene **100 partite di tutte le leghe del mondo**. Emetteva quindi un evento per ogni gol e ogni cartellino del pianeta, e le automazioni degli utenti li trasformavano in notifiche.

Lo screenshot in #11 lo conferma: mostra un cartellino di un giocatore che **non milita in nessuno dei campionati seguiti** da chi segnalava. Da lì le "più di 500 notifiche" di #11 e le 148 dopo il riavvio di #13.

L'integrazione non ha mai usato `persistent_notification` — verificato, non compare né qui né nella card — quindi la risposta data all'epoca era corretta. Il problema non era chi creava le notifiche, ma **quanti eventi venivano emessi**.

Ora emettono eventi solo i sensori legati a una squadra seguita.

## 2. `scan_interval` non era collegato a nulla

Il valore dell'opzione veniva salvato su `self._scan_interval` e **mai usato**. Senza una costante `SCAN_INTERVAL` nel modulo, HA applicava il default del dominio `sensor` — **30 secondi** — a tutti i sensori, ignorando i 3 minuti configurati.

Lo conferma indipendentemente il log di un utente in #20:

```
Updating calcio_live sensor took longer than the scheduled update interval 0:00:30
```

`should_poll` ora è `False` e l'update lo schedula l'entità stessa con `async_track_time_interval` sul proprio intervallo, disdetto in `async_will_remove_from_hass`.

Le due condizioni che rendono il cambio sicuro, verificate sul sorgente di `entity_platform.py`:

- l'update iniziale continua ad avvenire, perché `async_add_entities` è chiamata con `update_before_add=True` e quel percorso (`_async_add_and_update_entities`) è indipendente da `should_poll`;
- il timer di polling di HA non parte più, perché viene creato solo `if ... any(entity.should_poll for entity in entities)`.

Effetto collaterale positivo: le chiamate a ESPN calano di **6 volte** rispetto ai 30 secondi forzati, il che allevia anche i warning `is taking over 10 seconds` visti in #20.

## Rapporto con le altre PR

Verificato con `git merge-tree`: si fonde pulito con **`main`, #17, #19 e #21** singolarmente.

Nota per gli utenti che nel frattempo hanno filtrato a mano nelle automazioni: dopo questa PR il filtro sulla squadra non è più necessario per sopprimere le partite altrui, ma resta innocuo.
