### PR TITLE
ci: allega lo zip installabile alla release automatica

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -44,6 +44,36 @@ jobs:
             echo 'EOF_NOTES'
           } >> "$GITHUB_OUTPUT"
 
+      # Lo ZIP deve contenere i file dell'integrazione ALLA RADICE, non sotto
+      # custom_components/calcio_live/: HACS lo estrae con
+      # zip_file.extractall(<config>/custom_components/calcio_live) senza
+      # rimuovere alcun prefisso di percorso. La stessa struttura va bene anche
+      # per l'installazione manuale.
+      - name: Build integration zip
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          cd custom_components/calcio_live
+          zip -r "$GITHUB_WORKSPACE/calcio_live.zip" . \
+            -x '*.pyc' -x '__pycache__/*' -x '*/__pycache__/*' -x '*.DS_Store'
+          cd "$GITHUB_WORKSPACE"
+          echo "Contenuto dello zip:"
+          unzip -l calcio_live.zip
+
+      - name: Verify zip layout
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          # manifest.json deve stare alla radice dello zip, altrimenti HACS
+          # installerebbe l'integrazione in una sottocartella e HA non la vede.
+          if ! unzip -l calcio_live.zip | grep -qE ' manifest\.json$'; then
+            echo "::error::manifest.json non è alla radice dello zip"
+            exit 1
+          fi
+          ZIP_VERSION=$(unzip -p calcio_live.zip manifest.json | jq -r '.version')
+          if [ "$ZIP_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "::error::versione nello zip ($ZIP_VERSION) diversa da quella attesa (${{ steps.version.outputs.version }})"
+            exit 1
+          fi
+
       - name: Create tag and release
         if: steps.check.outputs.exists == 'false'
         uses: softprops/action-gh-release@v2
@@ -51,5 +81,6 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }}
           body: ${{ steps.notes.outputs.notes }}
+          files: calcio_live.zip
           draft: false
           prerelease: false


### PR DESCRIPTION
Il workflow `auto-release.yml` crea tag e release a ogni bump di `manifest.json`, ma **senza allegare nulla**: tutte le release da v2.8.0 in poi hanno solo i tarball sorgente generati da GitHub. Non esiste un pacchetto pronto da scaricare.

```
$ gh release view v2.11.3 --json assets
(nessun asset)
```

## Cosa cambia

Ogni release porta ora `calcio_live.zip` con i file dell'integrazione **alla radice** dell'archivio, non sotto `custom_components/calcio_live/`.

La struttura non è arbitraria. HACS estrae l'asset così (`async_download_zip_file`, `repositories/base.py`):

```python
def _extract_zip_file():
    with zipfile.ZipFile(temp_file, "r") as zip_file:
        zip_file.extractall(self.content.path.local)
```

Nessuno strip di prefisso, e `content.path.local` è già `<config>/custom_components/calcio_live`. Un archivio annidato finirebbe in `custom_components/calcio_live/custom_components/calcio_live/` e HA non vedrebbe l'integrazione. La stessa struttura è quella giusta anche per l'installazione manuale.

## Verifica

Un secondo step fallisce la build se `manifest.json` non è alla radice o se la versione nello zip non corrisponde al tag. Senza, un errore di impacchettamento produrrebbe una release rotta in silenzio.

Provato in locale, inclusa la simulazione dell'estrazione HACS:

```
17 file nello zip
sim/custom_components/calcio_live/manifest.json      <- HA lo trova
sim/custom_components/calcio_live/sensor.py
sim/custom_components/calcio_live/sensori/
sim/custom_components/calcio_live/translations/
```

Esclusi `.pyc`, `__pycache__` e `.DS_Store`: non sono tracciati, ma così lo zip locale è identico a quello della CI.

## Cosa NON cambia, di proposito

`hacs.json` resta invariato. Aggiungere `"zip_release": true` + `"filename": "calcio_live.zip"` farebbe scaricare a HACS il singolo zip invece dei file dal repository — più veloce e con meno chiamate API — ma **renderebbe non installabili tutte le release precedenti**, che l'asset non ce l'hanno. Chi volesse tornare a una versione più vecchia otterrebbe un errore di download.

Se lo si vuole, la strada pulita è: prima allegare lo zip anche alle release passate, poi accendere il flag. Volutamente fuori da questa PR.
