### PR TITLE
v2.12.0 🐛 Serie A vuota, punteggi live sul mixed, notifiche a raffica

### DIFF
--- a/custom_components/calcio_live/manifest.json
+++ b/custom_components/calcio_live/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Bobsilvio/calcio_live/issues",
   "requirements": ["arrow", "aiofiles", "pytz==2023.3"],
-  "version": "2.11.3"
+  "version": "2.12.0"
 }


### PR DESCRIPTION
> ⚠️ **Da mergiare per ultima.** Questa PR contiene solo il bump di `manifest.json`, che è ciò che fa scattare `auto-release.yml` e quindi la pubblicazione della release scaricabile. Nessuna delle altre PR tocca il manifest, di proposito: così esce **una sola release** con dentro tutto, invece di quattro ravvicinate.

Ordine consigliato: #17 → #23 → #19 → #21 → #22 → questa.

(#23 conviene prima delle altre così la release che nasce da qui porta già `calcio_live.zip` allegato.)

---

Raccoglie le fix di #17, #19, #21, #22 e #23.

### Partite Serie A sempre vuote (#20)

ESPN rifiuta con `HTTP 400` ogni finestra di date oltre i **365 giorni**, e la Serie A ne dichiara **391**: tutte le richieste fallivano, in modo deterministico. Liga, Premier, Bundesliga ed Europa League ne dichiarano esattamente 365 — passavano per un giorno di margine. `ita.1` passa da 0 a **380 partite**.

### Punteggi live assenti sul sensore mixed (#18)

L'endpoint `/teams/{id}/schedule` ha una struttura diversa dallo scoreboard e i campi venivano letti nei posti sbagliati: stato, punteggi e nome competizione erano sempre `"N/A"`, quindi `has_live_match` non diventava mai vero e le card restavano senza risultati.

In più `?fixture=true` restituisce **solo** le partite future e senza il parametro **solo** quelle giocate: il sensore non poteva vedere risultati, per costruzione. Ora le sorgenti vengono unite, con `/all/scoreboard` come riferimento per lo stato live. Corretta anche la finestra stagionale, che il mixed ereditava da una singola competizione e che poteva svuotarlo del tutto.

### Notifiche a raffica (#11, #13)

Il sensore "tutte le partite di oggi" emetteva eventi gol e cartellino per tutte le **~100 partite del mondo**, non solo per le squadre seguite. Le automazioni degli utenti le trasformavano fedelmente in centinaia di notifiche. Ora emettono eventi solo i sensori legati a una squadra.

### `scan_interval` ignorato

L'opzione non era collegata a nulla: HA interrogava ESPN **ogni 30 secondi** qualunque valore fosse configurato. Ora l'intervallo viene rispettato, con gli update serializzati per evitare esecuzioni sovrapposte.

### Classifica persa per una squadra senza logo (#20)

Una sola squadra priva di logo faceva fallire l'**intera** classifica, che tornava vuota e riprovava a ogni update. Corretto anche l'anno di stagione, fisso al **2024** nel codice: da un anno e mezzo `season` era `"N/A"` per tutti.

### Crash di thread-safety (#16)

`hass.async_create_task` veniva chiamata da un thread executor, cosa che HA tratta come errore per le integrazioni custom e che interrompeva l'update dell'entità.

### Altro

- Sensore mixed non più duplicato quando la stessa squadra è configurata su più competizioni
- `async_unload_entry` finalmente presente: rimuovere una config entry non richiede più il riavvio
- Le release includono ora `calcio_live.zip` pronto da installare
- README: chiarito che l'esclusione dal recorder è necessaria, non consigliata, per i sensori `all_*`
